### PR TITLE
use in webpack with vue-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,15 @@ $ bower install vue-echarts
 ```js
 import ECharts from 'vue-echarts/src/components/ECharts.vue'
 
-// register component to use
+// register the component to use
 Vue.component('chart', ECharts)
+
+// or register in component
+export default {
+  components: {
+    chart: ECharts
+  }
+}
 ```
 
 ### CommonJS

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ $ bower install vue-echarts
 
 ## Registering the component
 
+### webpack
+```js
+import echarts from 'vue-echarts/src/components/ECharts.vue'
+
+export default {
+  components: {echarts}
+}
+```
 ### CommonJS
 
 ```js

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ $ bower install vue-echarts
 
 ## Registering the component
 
-### webpack
+### webpack + vue-loader
 ```js
-import echarts from 'vue-echarts/src/components/ECharts.vue'
+import ECharts from 'vue-echarts/src/components/ECharts.vue'
 
-export default {
-  components: {echarts}
-}
+// register component to use
+Vue.component('chart', ECharts)
 ```
+
 ### CommonJS
 
 ```js


### PR DESCRIPTION
使用 webpack 的时候必须直接引用 src 内的 vue 文件， 因为 npm 中配置的 main 指向了 dist 中的 js 文件会导致 webpack 在 build 的时候进行 uglyfy 的时候超级缓慢。
添加此使用方式以提醒使用者。