### PR TITLE
Enable options merging in watcher

### DIFF
--- a/src/components/ECharts.vue
+++ b/src/components/ECharts.vue
@@ -87,13 +87,13 @@ export default {
     }
   },
   watch: {
-    // use assign statements to tigger "options" and "group" setters
+    // use assign statements to trigger "options" and "group" setters
     options: {
       handler (options) {
         if (!this.chart && options) {
           this._init()
         } else {
-          this.chart.setOption(this.options, true)
+          this.chart.setOption(this.options)
         }
       },
       deep: true


### PR DESCRIPTION
At the moment the `notMerge` flag is set to `true` in the `setOption` call in the `options` watcher.
This means that the options object must contain all of the chart configuration; a merge is not possible.

By removing this flag the `options` will be merged.