### PR TITLE
更改clear和dispose的方式，在数据量大时可能阻塞render，将microtask提升到task

### DIFF
--- a/src/components/ECharts.vue
+++ b/src/components/ECharts.vue
@@ -139,10 +139,14 @@ export default {
       return this._delegateMethod('getConnectedDataURL', options)
     },
     clear() {
-      this._delegateMethod('clear')
+      setTimeout(() => {
+        this._delegateMethod('clear')
+      }, 0);
     },
     dispose() {
-      this._delegateMethod('dispose')
+      setTimeout(() => {
+        this._delegateMethod('dispose')
+      }, 0);
     },
     _delegateMethod(name, ...args) {
       if (!this.chart) {


### PR DESCRIPTION
项目中发现，当数据量很大时，直接clear或者dispose界面会卡顿很长时间，据了解是因为Vue异步操作DOM的机制相关，microTask执行结束才render导致页面卡死，使用setTimout来将其放到task队列，不是microTask。测试改了之后速度提升很快
![image](https://user-images.githubusercontent.com/4888672/30910881-1e3486b8-a3b9-11e7-8256-6594f116eb8c.png)

