### PR TITLE
echarts update to 3.8.0

### DIFF
--- a/src/components/ECharts.vue
+++ b/src/components/ECharts.vue
@@ -10,7 +10,7 @@
 </style>
 
 <script>
-import echarts from 'echarts/lib/echarts'
+import * as echarts from 'echarts/lib/echarts'
 import debounce from 'lodash.debounce'
 import Vue from 'vue'
 


### PR DESCRIPTION
echarts update to 3.8.0, the log say "Source code of echarts has been switched to ES Module, which enabled tree shaking of bundle and reduced size."